### PR TITLE
Handle user cancellation in selection dialog

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -31,13 +31,15 @@ impl LacyCli {
                         println!("{}", results.first().unwrap().display().to_string());
                     },
                     _ => {
-                        println!("{}", ui::select(
+                        if let Some(selected) = ui::select(
                             "Multiple possibilities found!",
                             results
                                 .iter()
                                 .map(|path_buf| path_buf.display().to_string())
-                                .collect::<Vec<String>>()
-                        ));
+                                .collect::<Vec<String>>(),
+                        ) {
+                            println!("{}", selected);
+                        }
                     }
                 };
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,14 @@
 use dialoguer::{theme::ColorfulTheme, Select};
 
-pub fn select(title: &str, options: Vec<String>) -> String {
-    let selection = Select::with_theme(&ColorfulTheme::default())
+pub fn select(title: &str, options: Vec<String>) -> Option<String> {
+    if let Some(selection) = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(title)
         .items(&options)
         .default(0)
-        .interact()
-        .unwrap();
-    options[selection].to_string()
+        .interact_opt()
+        .unwrap()
+    {
+        return Some(options[selection].to_string());
+    }
+    None
 }


### PR DESCRIPTION
Previously users could only exit with ^C, which would leave the terminal cursor hidden. Now users can cancel with Esc/q and the terminal state is properly restored.