### PR TITLE
feat: Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /test
+.direnv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# artifacts
 /target
+/result
+
+# misc
 /test
 .direnv

--- a/README.md
+++ b/README.md
@@ -98,6 +98,78 @@ cargo install lacy
 brew install timothebot/tap/lacy
 ```
 
+#### NixOS (with Flakes and Home Manager)
+
+Run `lacy` directly:
+```sh
+nix run github:timothebot/lacy
+```
+
+Or, add `lacy` to your system configuration:
+
+Add `lacy` to your `flake.nix` inputs:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    lacy.url = "github:timothebot/lacy";
+    # ... other inputs
+  };
+
+  outputs = { self, nixpkgs, lacy, ... }@inputs: {
+    # ...
+  };
+}
+```
+
+Then, in your `home-manager` configuration, import the `lacy` module and enable it:
+
+```nix
+# home.nix
+{
+  imports = [
+    inputs.lacy.homeManagerModules.default
+  ];
+
+  programs.lacy.enable = true;
+}
+```
+
+Rebuild your system for the changes to take effect.
+
+### Using as an Overlay
+
+Alternatively, you can use the `lacy` flake as an overlay. This is useful if you prefer to manage your packages directly without using the provided Home Manager module.
+
+#### For NixOS
+
+1.  Add `lacy` to your `flake.nix` inputs.
+2.  Apply the overlay to your NixOS configuration and add the package to `environment.systemPackages`.
+
+    ```nix
+    # In your NixOS configuration (e.g., /etc/nixos/configuration.nix)
+    { pkgs, inputs, ... }: {
+      nixpkgs.overlays = [ inputs.lacy.overlays.default ];
+
+      environment.systemPackages = [ pkgs.lacy ];
+    }
+    ```
+
+#### For Home Manager
+
+1.  Add `lacy` to your `flake.nix` inputs.
+2.  Apply the overlay to your Home Manager configuration and add the package to `home.packages`.
+
+    ```nix
+    # In your home-manager configuration (e.g., ~/.config/nixpkgs/home.nix)
+    { pkgs, inputs, ... }: {
+      nixpkgs.overlays = [ inputs.lacy.overlays.default ];
+
+      home.packages = [ pkgs.lacy ];
+    }
+    ```
+
 ### Shell Setup
 
 #### Zsh

--- a/README.md
+++ b/README.md
@@ -98,16 +98,9 @@ cargo install lacy
 brew install timothebot/tap/lacy
 ```
 
-#### NixOS (with Flakes and Home Manager)
+#### NixOS (with Flakes and Home Manager) ❄️
 
-Run `lacy` directly:
-```sh
-nix run github:timothebot/lacy
-```
-
-Or, add `lacy` to your system configuration:
-
-Add `lacy` to your `flake.nix` inputs:
+There are a couple of ways to get `lacy` up and running on your Nix system. Both methods require adding `lacy` to your `flake.nix` inputs.
 
 ```nix
 # flake.nix
@@ -123,11 +116,16 @@ Add `lacy` to your `flake.nix` inputs:
 }
 ```
 
-Then, in your `home-manager` configuration, import the `lacy` module and enable it:
+##### 1. Home Manager Module (Recommended)
+
+This is the easiest way to manage `lacy` if you're using Home Manager. The module handles most of the setup for you. You **must** explicitly add the `lacy` flake as an **overlay** to your configuration to ensure the `lacy` package is available.
 
 ```nix
 # home.nix
-{
+{ pkgs, inputs, ... }: {
+  # Explicitly add the overlay to make lacy visible in your pkgs set
+  nixpkgs.overlays = [ inputs.lacy.overlays.default ];
+
   imports = [
     inputs.lacy.homeManagerModules.default
   ];
@@ -136,39 +134,39 @@ Then, in your `home-manager` configuration, import the `lacy` module and enable 
 }
 ```
 
-Rebuild your system for the changes to take effect.
+##### 2. Nix Overlay (NixOS / Home Manager)
 
-### Using as an Overlay
+If you prefer to manage packages directly without using the Home Manager module, this is the way to go. You apply the overlay and then add the `lacy` package to your system or user packages.
 
-Alternatively, you can use the `lacy` flake as an overlay. This is useful if you prefer to manage your packages directly without using the provided Home Manager module.
+**For NixOS:**
 
-#### For NixOS
+```nix
+# In your NixOS configuration (e.g., /etc/nixos/configuration.nix)
+{ pkgs, inputs, ... }: {
+  nixpkgs.overlays = [ inputs.lacy.overlays.default ];
 
-1.  Add `lacy` to your `flake.nix` inputs.
-2.  Apply the overlay to your NixOS configuration and add the package to `environment.systemPackages`.
+  environment.systemPackages = [ pkgs.lacy ];
+}
+```
 
-    ```nix
-    # In your NixOS configuration (e.g., /etc/nixos/configuration.nix)
-    { pkgs, inputs, ... }: {
-      nixpkgs.overlays = [ inputs.lacy.overlays.default ];
+**For Home Manager:**
 
-      environment.systemPackages = [ pkgs.lacy ];
-    }
-    ```
+```nix
+# In your home-manager configuration (e.g., ~/.config/nixpkgs/home.nix)
+{ pkgs, inputs, ... }: {
+  nixpkgs.overlays = [ inputs.lacy.overlays.default ];
 
-#### For Home Manager
+  home.packages = [ pkgs.lacy ];
+}
+```
 
-1.  Add `lacy` to your `flake.nix` inputs.
-2.  Apply the overlay to your Home Manager configuration and add the package to `home.packages`.
+##### 3. Run `lacy` directly
 
-    ```nix
-    # In your home-manager configuration (e.g., ~/.config/nixpkgs/home.nix)
-    { pkgs, inputs, ... }: {
-      nixpkgs.overlays = [ inputs.lacy.overlays.default ];
+Just want to try it out? You can run `lacy` from the command line without adding it to your system configuration.
 
-      home.packages = [ pkgs.lacy ];
-    }
-    ```
+```sh
+nix run github:timothebot/lacy
+```
 
 ### Shell Setup
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,134 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1756795219,
+        "narHash": "sha256-tKBQtz1JLKWrCJUxVkHKR+YKmVpm0KZdJdPWmR2slQ8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "80dbdab137f2809e3c823ed027e1665ce2502d74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756911493,
+        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756597274,
+        "narHash": "sha256-wfaKRKsEVQDB7pQtAt04vRgFphkVscGRpSx3wG1l50E=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "21614ed2d3279a9aa1f15c88d293e65a98991b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,45 +1,74 @@
 {
   "nodes": {
-    "fenix": {
+    "flakelight": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756795219,
-        "narHash": "sha256-tKBQtz1JLKWrCJUxVkHKR+YKmVpm0KZdJdPWmR2slQ8=",
+        "lastModified": 1757335773,
+        "narHash": "sha256-MpPsb/ZwFQnngBKvmbtNn53LI3D5shhjl2tx7qh2by0=",
         "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "80dbdab137f2809e3c823ed027e1665ce2502d74",
+        "repo": "flakelight",
+        "rev": "06b8bc9debad318f240db984be9b8e36b3ab742b",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "repo": "fenix",
+        "repo": "flakelight",
         "type": "github"
       }
     },
-    "flake-parts": {
+    "home-manager": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "lastModified": 1757598712,
+        "narHash": "sha256-5PWVrdMp8u31Q247jqnJcwxKg3MJrs1TadTyTBRVBDY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "6d7c11a0adee0db21e3a8ef90ae07bb89bc20b8f",
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
+        "owner": "nix-community",
+        "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1756911493,
         "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
@@ -55,77 +84,11 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "fenix": "fenix",
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756597274,
-        "narHash": "sha256-wfaKRKsEVQDB7pQtAt04vRgFphkVscGRpSx3wG1l50E=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "21614ed2d3279a9aa1f15c88d293e65a98991b30",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "flakelight": "flakelight",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_3"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+    description = "Fast magical cd alternative for lazy terminal navigators";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    utils.url = "github:numtide/flake-utils";
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ flake-parts, nixpkgs, fenix, utils, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      flake = {
+        homeManagerModules.default = { config, lib, pkgs, ... }:
+          with lib;
+          let
+            cfg = config.programs.lacy;
+          in
+          {
+            options.programs.lacy = {
+              enable = mkEnableOption "lacy - magical cd alternative";
+
+              package = mkOption {
+                type = types.package;
+                default = inputs.self.packages.${pkgs.system}.default;
+                description = "The lacy package to use.";
+              };
+            };
+
+            config = mkIf cfg.enable {
+              programs.bash.initExtra = mkIf config.programs.bash.enable ''
+                eval "$(${cfg.package}/bin/lacy init zsh)"
+              '';
+
+              programs.zsh.initContent = mkIf config.programs.zsh.enable ''
+                eval "$(${cfg.package}/bin/lacy init zsh)"
+              '';
+            };
+          };
+      };
+
+      perSystem = { config, self', inputs', pkgs, system, manifest, ... }:
+      let
+        manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+       in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+            pname = manifest.name;
+            version = manifest.version;
+            cargoLock.lockFile = ./Cargo.lock;
+            src = ./.;
+            nativeBuildInputs = with pkgs; [
+                pkg-config
+            ];
+          meta = with pkgs.lib; {
+            description = "Fast magical cd alternative for lazy terminal navigators";
+            homepage = "https://github.com/timothebot/lacy";
+            license = licenses.mit;
+            maintainers = [ ];
+            platforms = platforms.unix;
+          };
+        };
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.python314
+            fenix.packages.${system}.stable.toolchain
+          ];
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self'.packages.default}/bin/lacy";
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -85,13 +85,7 @@
 
         app = { lacy, ... }: "${lacy}/bin/lacy";
 
-        systems = [
-          "x86_64-linux"
-          "aarch64-linux"
-          "i686-linux"
-          "armv7l-linux"
-        ];
-
+        systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
           };
 
         devShell = {
-          packages = pkgs: with pkgs; [ python314 ];
+          packages = pkgs: with pkgs; [ cargo rustc ];
         };
 
         app = { lacy, ... }: "${lacy}/bin/lacy";

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,18 @@
             nix-update-script,
             ...
           }:
+          let
+            manifest = (lib.importTOML ./Cargo.toml).package;
+          in
           rustPlatform.buildRustPackage (finalAttrs: {
-            pname = "lacy";
-            version = "0.3.0";
+            pname = manifest.name;
+            version = manifest.version;
 
             src = ./.;
 
             passthru.updateScript = nix-update-script { };
 
-            # Remove in 0.3.1 once tests do not rely on folders
-            doCheck = false;
-
-            cargoHash = "sha256-N5avoN3QCCYMF29Cvbwha+iBAXPncOttWxGpVZ70EqI=";
+            cargoHash = "sha256-FLDAiPjqj86Uj0c095gcYhUnITlq4qVkDWN2sdEb/xQ=";
 
             meta = {
               description = "Fast magical cd alternative for lacy terminal navigators";
@@ -77,16 +77,17 @@
           };
 
         devShell = {
-          packages =
-            pkgs: with pkgs; [
-              python314
-            ];
+          packages = pkgs: with pkgs; [ python314 ];
         };
 
         app = { lacy, ... }: "${lacy}/bin/lacy";
 
-        systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ];
       }
     );
 }
- 


### PR DESCRIPTION
# Adding nix flake
I just only replaced few things from original implementation from nix-flake branch  

## Use of flakelight instead of flake-parts 
Using flakelight make it cleaner as it will bring hidden benefits like nix files auto-loading in feature in case modules or package evolve

## Package definition from https://github.com/NixOS/nixpkgs/pull/440869
I think that keeping in sync those definitions is good approach, as we can test the changes to derivation here and just in case backport them to nixpkgs

# Open questions
- Do we need module also for nixos? (It is just linking already existing one to nixosModule property

# Tested 
with https://gist.github.com/declnix/4357af8f72ff5c427b43b60f9c99a61e

Feedback appreciated :) 

Resolves #6 