### PR TITLE
feat: Improve treatment of symlinks

### DIFF
--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, fs, path::PathBuf};
 
 use crate::{
     cmd::{Prompt, Run},
@@ -40,6 +40,24 @@ impl Run for Prompt {
                     .iter()
                     .map(|path_buf| path_buf.display().to_string())
                     .collect::<Vec<String>>();
+
+                // Canonicalize the paths to see if we have two different paths pointing
+                // to the same location
+                let filtered_paths = paths
+                    .clone()
+                    .into_iter()
+                    .map(|path| {
+                        fs::canonicalize(&path)
+                            .map(|canonicalized| canonicalized.display().to_string())
+                            .unwrap_or(path.to_string())
+                    })
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<String>>();
+                if filtered_paths.len() == 1 {
+                    println!("{}", filtered_paths.first().unwrap());
+                    return;
+                }
                 if self.return_all {
                     println!("{}", paths.join("\n"));
                     return;

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -106,6 +106,12 @@ impl TryFrom<&Path> for Directory {
     type Error = ();
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        if path.is_symlink() {
+            return Ok(Directory::new(
+                path.file_name().ok_or(())?.display().to_string(),
+                path.to_path_buf(),
+            ));
+        }
         if path.is_dir() {
             let Some(file_name) = path.file_name() else {
                 return Ok(Directory::new(String::new(), path.to_path_buf()));
@@ -113,12 +119,6 @@ impl TryFrom<&Path> for Directory {
             return Ok(Directory::new(
                 file_name.display().to_string(),
                 path.to_path_buf(),
-            ));
-        }
-        if path.is_symlink() {
-            return Ok(Directory::new(
-                path.file_name().ok_or(())?.display().to_string(),
-                path.read_link().map_err(|_| ())?,
             ));
         }
         Err(())


### PR DESCRIPTION
If you now get multiple results pointing to the same location (via symlinks), it will check that and only return one result.