### PR TITLE
a bunch of small fixes (dw most of the diff is cargo lock) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,28 +34,35 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys",
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
@@ -68,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -80,9 +87,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -102,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -120,21 +127,20 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.61.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -145,7 +151,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys 0.61.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -156,15 +162,13 @@ checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
  "shell-words",
- "tempfile",
- "zeroize",
 ]
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
  "block2",
@@ -179,32 +183,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
+ "wasip3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -213,10 +245,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lacy"
@@ -230,16 +286,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nix"
@@ -255,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -270,9 +344,25 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -294,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustix"
@@ -308,23 +398,38 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,10 +437,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
+name = "serde_json"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "strsim"
@@ -364,20 +482,26 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "upon"
@@ -386,8 +510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ead40aa15464f4d808014183fa0b030761ff6f57e162f7fc76d6a900df7a28"
 dependencies = [
  "serde",
- "unicode-ident",
- "unicode-width",
 ]
 
 [[package]]
@@ -397,119 +519,168 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wasip2",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "zeroize"
-version = "1.8.1"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ keywords = ["cli", "tool", "utility"]
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 ctrlc = { version = "3.5.2", features = ["termination"] }
-dialoguer = "0.12.0"
-upon = "0.10.0"
+dialoguer = { version = "0.12.0", default-features = false }
+upon = { version = "0.10.0", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"
@@ -28,3 +28,4 @@ tempfile = "3.27.0"
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ lacy init fish | source
 <details>
 <summary>Nushell</summary>
 
-You can't set the lacy alias (`--cmd`) to `cd`. More infos below the table at [Shell Options](https://lacy.tiimo.space/setup.html#shell-options).
+You'll need a small hack to set lacy alias (`--cmd`) to `cd`. Check [docs](https://lacy.tiimo.space/setup.html#--cmd).
 
 ```bash
 # $nu.config-path

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ lacy init fish | source
 <details>
 <summary>Nushell</summary>
 
-You'll need a small hack to set lacy alias (`--cmd`) to `cd`. Check [docs](https://lacy.tiimo.space/setup.html#--cmd).
+<!-- Remove this in like 2027 when everyone gets v0.113+ -->
+If you're running anything older than v0.112, you'll need `lacy init nu --cd-cmd=cd`.
+If you're running anything older than v0.113, you'll also need a small hack to set lacy alias (`--cmd`) to `cd`. Check [docs](https://lacy.tiimo.space/setup.html#--cmd).
 
 ```bash
 # $nu.config-path

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -29,7 +29,9 @@ lacy init fish | source
 
 ### Nushell
 
-You'll need a small hack to set lacy alias (`--cmd`) to `cd`. Check [`--cmd`](#--cmd).
+<!-- Remove this in like 2027 when everyone gets v0.113+ -->
+If you're running anything older than v0.112, you'll need `lacy init nu --cd-cmd=cd`.
+If you're running anything older than v0.113, you'll also need a small hack to set lacy alias (`--cmd`) to `cd`. Check [`--cmd`](#--cmd).
 
 ```bash
 # $nu.config-path
@@ -59,7 +61,7 @@ Define the command to be used instead of `cd`. (e.g. `--cd-cmd=z`)
 Default:
 
 - Bash, ZSH, Fish: `builtin cd`
-- Nushell: `cd`
+- Nushell: `%cd`
 - PowerShell: `Set-Location`
 
 ### `--cmd`
@@ -69,10 +71,13 @@ The name of the main lacy command you use for navigating. (e.g. `--cmd=cd`)
 Default: `y`
 
 > [!WARNING]
-> Nushell doesn't intrinsically have `builtin`, so `--cmd=cd` will cause infinite recursion.
-> See [issue in nushell repo](https://github.com/nushell/nushell/issues/3792) and [nushell book](https://www.nushell.sh/book/aliases.html#replacing-existing-commands-using-aliases).
-> 
-> Luckily, there is a hack:
+> Even though nushell has an analogue of `builtin` keyword - which is the `%` sigil,
+> it was only added recently in v0.112 (and will break older versions!),
+> and it was actually bugged to the point that `--cmd=cd` would still have
+> caused infinite recursion, and that only got fixed in v0.113.
+>
+> So if you're running older versions, use this hack from the very
+> [nushell book](https://www.nushell.sh/book/aliases.html#replacing-existing-commands-using-aliases):
 > ```bash
 > alias core-cd = cd
 > mkdir ($nu.data-dir | path join "vendor/autoload")

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -29,7 +29,7 @@ lacy init fish | source
 
 ### Nushell
 
-You can't set the lacy alias (`--cmd`) to `cd`. More infos at [`--cmd`](#--cmd).
+You'll need a small hack to set lacy alias (`--cmd`) to `cd`. Check [`--cmd`](#--cmd).
 
 ```bash
 # $nu.config-path
@@ -69,9 +69,15 @@ The name of the main lacy command you use for navigating. (e.g. `--cmd=cd`)
 Default: `y`
 
 > [!WARNING]
-> Nushell doesn't have a `builtin cd` option,
-> so setting it `--cmd=cd` will cause a loop.
-> It should be possible to bypass this with some tinkering ([issue in nushell repo](https://github.com/nushell/nushell/issues/3792)). Feel free to open a PR if you have a good solution!
+> Nushell doesn't intrinsically have `builtin`, so `--cmd=cd` will cause infinite recursion.
+> See [issue in nushell repo](https://github.com/nushell/nushell/issues/3792) and [nushell book](https://www.nushell.sh/book/aliases.html#replacing-existing-commands-using-aliases).
+> 
+> Luckily, there is a hack:
+> ```bash
+> alias core-cd = cd
+> mkdir ($nu.data-dir | path join "vendor/autoload")
+> lacy init nu --cd-cmd=core-cd --cmd=cd | save -f ($nu.data-dir | path join "vendor/autoload/lacy.nu")
+> ```
 
 ### `--custom-fuzzy`
 

--- a/src/cmd/commands.rs
+++ b/src/cmd/commands.rs
@@ -58,27 +58,26 @@ pub struct Prompt {
 #[command(
     version,
     help_template=HELP_TEMPLATE,
-    after_help = "
-To get started, you must include lacy in your shell config.
+    after_help = r##"To get started, you must include lacy in your shell config.
 You can find more about why this is required in the docs.
 
 If you don't know what shell you are using, run:
 $ echo $SHELL
 
 ZSH:
-$ echo \"eval \\\"\\$(lacy init zsh)\\\"\" >> ~/.zshrc
+$ echo "eval \"\$(lacy init zsh)\"" >> ~/.zshrc
 
 Bash:
-$ echo \"eval \\\"\\$(lacy init bash)\\\"\" >> ~/.bashrc
+$ echo "eval \"\$(lacy init bash)\"" >> ~/.bashrc
 
 Fish:
-$ echo \"lacy init fish | source\" >> ~/.config/fish/config.fish
+$ echo "lacy init fish | source" >> ~/.config/fish/config.fish
 
 Nu (check docs before updating init options for nu):
-$ echo r#'mkdir ($nu.data-dir | path join \"vendor/autoload\"); lacy init nu | save -f ($nu.data-dir | path join \"vendor/autoload/lacy.nu\")'# o>> $nu.config-path
+$ echo r#'mkdir ($nu.data-dir | path join "vendor/autoload"); lacy init nu | save -f ($nu.data-dir | path join "vendor/autoload/lacy.nu")'# o>> $nu.config-path
 
 PowerShell:
-$ echo \"lacy init powershell | Out-String | iex\" >> $PROFILE"
+$ echo "lacy init powershell | Out-String | iex" >> $PROFILE"##
 )]
 pub struct Init {
     /// Currently supported shells: bash, fish, zsh, nu, powershell

--- a/src/cmd/complete.rs
+++ b/src/cmd/complete.rs
@@ -19,7 +19,7 @@ impl Run for Complete {
                         Some(path_buf.display().to_string())
                     }
                 })
-                .collect::<Vec<String>>()
+                .collect::<Vec<_>>()
                 .join(" ")
         );
     }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -10,10 +10,10 @@ impl Run for Init {
                 self.shell.as_str(),
                 &self.cd_cmd,
                 &self.cmd,
-                &self.custom_fuzzy
+                self.custom_fuzzy.as_ref()
             ) {
                 Ok(config) => config,
-                Err(err) => format!("An error occurred: {}", err),
+                Err(err) => format!("An error occurred: {err}"),
             }
         );
     }
@@ -23,15 +23,15 @@ pub fn shell_config(
     shell: &str,
     cd_cmd: &String,
     cmd: &String,
-    custom_fuzzy: &Option<String>,
+    custom_fuzzy: Option<&String>,
 ) -> Result<String, Error> {
     let mut engine = Engine::new();
 
-    let _ = engine.add_template("bash", include_str!("../../templates/bash.sh"));
-    let _ = engine.add_template("zsh", include_str!("../../templates/zsh.sh"));
-    let _ = engine.add_template("fish", include_str!("../../templates/fish.fish"));
-    let _ = engine.add_template("nu", include_str!("../../templates/nu.nu"));
-    let _ = engine.add_template("powershell", include_str!("../../templates/powershell.ps1"));
+    engine.add_template("bash", include_str!("../../templates/bash.sh"))?;
+    engine.add_template("zsh", include_str!("../../templates/zsh.sh"))?;
+    engine.add_template("fish", include_str!("../../templates/fish.fish"))?;
+    engine.add_template("nu", include_str!("../../templates/nu.nu"))?;
+    engine.add_template("powershell", include_str!("../../templates/powershell.ps1"))?;
 
     // Overwrite the default cd_cmd for certain shells
     let cd_cmd = if cd_cmd == "builtin cd" {
@@ -57,7 +57,7 @@ pub fn shell_config(
             },
             custom_fuzzy: {
                 enabled: &custom_fuzzy.is_some(),
-                cmd: custom_fuzzy.clone().unwrap_or_default()
+                cmd: custom_fuzzy.as_ref()
             }
         })
         .to_string()

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -37,8 +37,7 @@ pub fn shell_config(
     let cd_cmd = if cd_cmd == "builtin cd" {
         match shell {
             "powershell" => "Set-Location",
-            // Nushell does not have a builtin command
-            "nu" => "cd",
+            "nu" => "%cd",
             _ => cd_cmd,
         }
     } else {

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashSet, env, fs, path::PathBuf};
+use std::{env, fs, path::PathBuf};
+
+use dialoguer::console::Term;
 
 use crate::{
     cmd::{Prompt, Run},
@@ -14,7 +16,7 @@ impl Run for Prompt {
         if query.parts().is_empty() {
             println!(
                 "{}",
-                env::var("LACY_NO_ARGS_PATH").unwrap_or_else(|_| String::from("~"))
+                env::var("LACY_NO_ARGS_PATH").unwrap_or(String::from("~"))
             );
             return;
         }
@@ -44,44 +46,42 @@ impl Run for Prompt {
                 println!("{}", results.first().unwrap().display());
             }
             _ => {
-                let paths = results
-                    .iter()
-                    .map(|path_buf| path_buf.display().to_string())
-                    .collect::<Vec<String>>();
+                let paths = {
+                    let mut tmp = results
+                        .iter()
+                        .map(|path| {
+                            // Canonicalize the paths to see if we have two different paths
+                            // pointing to the same location
+                            fs::canonicalize(path)
+                                .unwrap()
+                                .to_str()
+                                .unwrap()
+                                .to_string()
+                        })
+                        .collect::<Vec<_>>();
+                    tmp.sort();
+                    tmp.dedup();
+                    tmp
+                };
 
-                // Canonicalize the paths to see if we have two different paths pointing
-                // to the same location
-                let filtered_paths = paths
-                    .clone()
-                    .into_iter()
-                    .map(|path| {
-                        fs::canonicalize(&path)
-                            .map(|canonicalized| canonicalized.display().to_string())
-                            .unwrap_or(path.to_string())
-                    })
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<String>>();
-                if filtered_paths.len() == 1 {
-                    println!("{}", filtered_paths.first().unwrap());
-                    return;
-                }
-                if self.return_all {
+                if paths.len() == 1 {
+                    println!("{}", paths.first().unwrap());
+                } else if self.return_all {
                     println!("{}", paths.join("\n"));
-                    return;
-                }
+                } else {
+                    // Prevents cursor from being hidden when canceling the selection.
+                    // See https://github.com/timothebot/lacy/issues/58.
+                    _ = ctrlc::set_handler(move || {
+                        let term = Term::stderr();
+                        _ = term.show_cursor();
+                        std::process::exit(1);
+                    });
 
-                // Prevents cursor from being hidden when canceling
-                // the selection. (See #58)
-                let _ = ctrlc::set_handler(move || {
-                    let term = dialoguer::console::Term::stderr();
-                    let _ = term.show_cursor();
-                    std::process::exit(1);
-                });
-                if let Some(selected) = ui::select("Multiple possibilities found!", paths) {
-                    println!("{}", selected);
+                    if let Some(selected) = ui::select("Multiple possibilities found!", &paths) {
+                        println!("{selected}");
+                    }
                 }
             }
-        };
+        }
     }
 }

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{collections::HashMap, env, fs};
 
 use dialoguer::console::Term;
 
@@ -39,48 +39,45 @@ impl Run for Prompt {
             }
              */
 
-        let results: Vec<PathBuf> = query.results(get_current_directory().as_path());
-        match results.len() {
-            0 => {}
-            1 => {
-                println!("{}", results.first().unwrap().display());
-            }
-            _ => {
-                let paths = {
-                    let mut tmp = results
-                        .iter()
-                        .map(|path| {
-                            // Canonicalize the paths to see if we have two different paths
-                            // pointing to the same location
-                            fs::canonicalize(path)
-                                .unwrap()
-                                .to_str()
-                                .unwrap()
-                                .to_string()
-                        })
-                        .collect::<Vec<_>>();
-                    tmp.sort();
-                    tmp.dedup();
-                    tmp
-                };
+        let paths = {
+            let map = query
+                .results(get_current_directory().as_path())
+                .iter()
+                .filter_map(|path| {
+                    Some((
+                        // Resolve symlinks, basically - so we can then
+                        // deduplicate paths that lead to the same directory
+                        fs::canonicalize(path)
+                            .ok()
+                            // Only leave directories and not files after symlinks
+                            .filter(|p| p.is_dir())?,
+                        // Store original path for display purposes
+                        path.to_str().map(|s| s.to_string())?,
+                    ))
+                })
+                // Collect this to a hashmap as it intristically deduplicates keys
+                .collect::<HashMap<_, _>>();
+            // Then return sorted user-displayed strings
+            let mut v = map.into_values().collect::<Vec<_>>();
+            v.sort_unstable();
+            v
+        };
 
-                if paths.len() == 1 {
-                    println!("{}", paths.first().unwrap());
-                } else if self.return_all {
-                    println!("{}", paths.join("\n"));
-                } else {
-                    // Prevents cursor from being hidden when canceling the selection.
-                    // See https://github.com/timothebot/lacy/issues/58.
-                    _ = ctrlc::set_handler(move || {
-                        let term = Term::stderr();
-                        _ = term.show_cursor();
-                        std::process::exit(1);
-                    });
+        if paths.len() == 1 {
+            println!("{}", paths.first().unwrap());
+        } else if self.return_all {
+            println!("{}", paths.join("\n"));
+        } else {
+            // Prevents cursor from being hidden when canceling the selection.
+            // See https://github.com/timothebot/lacy/issues/58.
+            _ = ctrlc::set_handler(move || {
+                let term = Term::stderr();
+                _ = term.show_cursor();
+                std::process::exit(1);
+            });
 
-                    if let Some(selected) = ui::select("Multiple possibilities found!", &paths) {
-                        println!("{selected}");
-                    }
-                }
+            if let Some(selected) = ui::select("Multiple possibilities found!", &paths) {
+                println!("{selected}");
             }
         }
     }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -69,7 +69,7 @@ impl ScoredDirectory {
     }
 }
 
-pub fn scored_directories(directories: Vec<Directory>, query: &str) -> Vec<ScoredDirectory> {
+pub fn scored_directories(directories: &[Directory], query: &str) -> Vec<ScoredDirectory> {
     directories
         .iter()
         .map(|directory| {
@@ -79,7 +79,7 @@ pub fn scored_directories(directories: Vec<Directory>, query: &str) -> Vec<Score
         .collect()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone)]
 pub struct Directory {
     /// The name of the directory
     name: String,

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,8 +1,11 @@
-use crate::directory::{sub_directories, Directory};
-use crate::query_part::QueryPart;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use crate::{
+    directory::{sub_directories, Directory},
+    query_part::QueryPart,
+};
+
+#[derive(Debug)]
 pub struct Query {
     query: String,
     parts: Vec<QueryPart>,
@@ -10,26 +13,26 @@ pub struct Query {
 
 impl From<String> for Query {
     fn from(query: String) -> Self {
-        let mut enhanced_query = query.clone().trim().replace("  ", " ");
+        let mut enhanced_query = query.trim().replace("  ", " ");
         if enhanced_query.trim().is_empty() {
             return Query {
                 query,
                 parts: vec![],
             };
         }
-        if enhanced_query.starts_with("/") {
+        if enhanced_query.starts_with('/') {
             enhanced_query = format!("##ROOT## {}", enhanced_query.strip_prefix("/").unwrap());
         }
-        if enhanced_query.ends_with("/") {
+        if enhanced_query.ends_with('/') {
             enhanced_query = enhanced_query.strip_suffix("/").unwrap().to_string();
         }
         enhanced_query = enhanced_query
             .replace(" / ", " ##ROOT## ")
-            .replace(" ", "/")
+            .replace(' ', "/")
             .replace("//", "/");
 
         let query_parts: Vec<QueryPart> = enhanced_query
-            .split("/")
+            .split('/')
             .map(|part| {
                 if part == "##ROOT##" {
                     return QueryPart::Root;
@@ -62,14 +65,13 @@ impl Query {
     }
 
     pub fn completions(&self, cwd: &Path) -> Vec<PathBuf> {
-        let query = self.query.clone();
-        if query.trim().is_empty() {
+        if self.query.trim().is_empty() {
             return sub_directories(cwd, 0)
                 .iter()
                 .map(|dir| dir.location().clone())
                 .collect();
         }
-        if query.ends_with(" ") {
+        if self.query.ends_with(' ') {
             return self
                 .results(cwd)
                 .iter()

--- a/src/query_part.rs
+++ b/src/query_part.rs
@@ -1,8 +1,8 @@
 use std::{env::home_dir, path::PathBuf};
 
-use crate::directory::{scored_directories, sub_directories, Directory};
+use crate::directory::{scored_directories, sub_directories, Directory, ScoredDirectory};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum QueryPart {
     /// ~
     Tilde,
@@ -25,10 +25,10 @@ impl From<&str> for QueryPart {
         match part {
             "" => QueryPart::Root,
             "~" => QueryPart::Tilde,
-            _ if part.starts_with("-") && part.replace("-", "").is_empty() => {
+            _ if part.starts_with('-') && part.replace('-', "").is_empty() => {
                 QueryPart::Skip(part.len() as u32 - 1)
             }
-            _ if part.starts_with("..") && part.replace(".", "").is_empty() => {
+            _ if part.starts_with("..") && part.replace('.', "").is_empty() => {
                 QueryPart::Back(part.len() as u32 - 1)
             }
             _ => QueryPart::Text(part.to_string()),
@@ -62,10 +62,7 @@ impl QueryPart {
                 let Some(target_dir) = dirs.first() else {
                     return vec![];
                 };
-                let mut target_location = target_dir.location().clone();
-                for _ in 0..*amount {
-                    target_location.push("..");
-                }
+                let target_location = target_dir.location().join("../".repeat(*amount as usize));
                 let Ok(dir) = Directory::try_from(target_location.as_path()) else {
                     return vec![];
                 };
@@ -73,35 +70,36 @@ impl QueryPart {
             }
             QueryPart::Text(text) => {
                 let mut scored_dirs = scored_directories(
-                    dirs.iter()
+                    &dirs
+                        .iter()
                         .flat_map(|dir| sub_directories(dir.location().as_path(), 0))
-                        .collect(),
+                        .collect::<Vec<_>>(),
                     text.as_str(),
                 );
 
                 let average_score: f64 = scored_dirs
                     .iter()
-                    .map(|scored_dir| scored_dir.score() as f64)
+                    .map(|scored_dir| f64::from(scored_dir.score()))
                     .sum::<f64>()
                     / scored_dirs.len() as f64;
 
                 let half_of_highest_score = scored_dirs
                     .iter()
-                    .map(|scored_dir| scored_dir.score())
+                    .map(ScoredDirectory::score)
                     .max()
                     .unwrap_or(0_i32)
                     / 2;
 
                 // sort by alphabetical order, then by score
                 scored_dirs.sort_by(|a, b| a.directory().location().cmp(b.directory().location()));
-                scored_dirs.sort_by_key(|a| a.score());
+                scored_dirs.sort_by_key(ScoredDirectory::score);
 
                 scored_dirs
                     .iter()
                     // remove dirs with low score
                     .filter(|scored_dir| {
-                        scored_dir.score() as f64 > 0.0
-                            && scored_dir.score() as f64 >= average_score
+                        f64::from(scored_dir.score()) > 0.0
+                            && f64::from(scored_dir.score()) >= average_score
                             && scored_dir.score() >= half_of_highest_score
                     })
                     .map(|scored_dir| scored_dir.directory().clone())

--- a/src/query_part.rs
+++ b/src/query_part.rs
@@ -90,9 +90,12 @@ impl QueryPart {
                     .unwrap_or(0_i32)
                     / 2;
 
-                // sort by alphabetical order, then by score
-                scored_dirs.sort_by(|a, b| a.directory().location().cmp(b.directory().location()));
-                scored_dirs.sort_by_key(ScoredDirectory::score);
+                // sort by score, if scores are equal by alphabetical order
+                scored_dirs.sort_unstable_by(|a, b| {
+                    a.score()
+                        .cmp(&b.score())
+                        .then(a.directory().location().cmp(b.directory().location()))
+                });
 
                 scored_dirs
                     .iter()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,15 +1,15 @@
 use dialoguer::{theme::ColorfulTheme, Select};
 
-pub fn select(title: &str, options: Vec<String>) -> Option<String> {
+pub fn select(title: &str, options: &Vec<String>) -> Option<String> {
     if let Some(selection) = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(title)
-        .items(&options)
+        .items(options)
         .default(0)
         .interact_opt()
         .ok()
         .flatten()
     {
-        return Some(options[selection].to_string());
+        return Some(options[selection].clone());
     }
     None
 }

--- a/templates/nu.nu
+++ b/templates/nu.nu
@@ -32,7 +32,9 @@ module lacy {
             if ($selected | path exists) and ($selected | path type) == "dir" {
                 {{ cd }} $selected
             }
-        {% endif %} } else if ($new_path | path type) in ["dir", "symlink"] {
+            # Even though path type normally also checks for path existing,
+            # for some reason (nothing) | path type is "dir". Likely a bug.
+        {% endif %} } else if ($new_path | path exists) and ($new_path | path type) in ["dir", "symlink"] {
             {{ cd }} $new_path
         } else {
             print $"Error: No matching directory found for '($query)'"

--- a/templates/nu.nu
+++ b/templates/nu.nu
@@ -32,12 +32,13 @@ module lacy {
             if ($selected | path exists) and ($selected | path type) == "dir" {
                 {{ cd }} $selected
             }
-        {% endif %} } else if ($new_path | path exists) and ($new_path | path type) == "dir" {
+        {% endif %} } else if ($new_path | path type) in ["dir", "symlink"] {
             {{ cd }} $new_path
         } else {
             print $"Error: No matching directory found for '($query)'"
         }
     }
 }
+
 use lacy {{ lacy_cmd }}
 # END generated Lacy shell config

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7,7 +7,10 @@ fn symlink<P: AsRef<std::path::Path>, Q: AsRef<std::path::Path>>(
 ) -> std::io::Result<()> {
     std::os::windows::fs::symlink_dir(src, dst)
 }
-use std::{fs, path::PathBuf};
+use std::{
+    fs::{self, canonicalize},
+    path::PathBuf,
+};
 
 use lacy::query::Query;
 use tempfile::TempDir;
@@ -61,10 +64,7 @@ impl TempEnv {
         for dir in dir_list {
             let path = tmpdir.path().join("test").join(dir);
             if !path.exists() {
-                let result = fs::create_dir_all(path);
-                if result.is_err() {
-                    panic!("Error, couldn't create test folder in tempdir!");
-                }
+                fs::create_dir_all(path).expect("Error, couldn't create test folder in tempdir!");
             }
         }
 
@@ -253,5 +253,36 @@ fn test_symlinks() {
             env.abs_path("test/alpha/beta/gamma3"),
             env.abs_path("test/link/beta/gamma3")
         ]
+    );
+}
+
+#[test]
+fn test_dots() {
+    let env = TempEnv::new();
+
+    fn resolve_query(path: PathBuf, query: &str) -> Vec<PathBuf> {
+        let query = Query::from(query.to_string());
+        query
+            .results(&path)
+            .iter()
+            // without canonicalize, `resolve_query(env.abs_path("epsilon/beta/chi6"), "..")`
+            // would just return `epsilon/beta/chi6/..`, which is fine for actual usage
+            // since it is further resolved by the os, but not for testing.
+            .map(canonicalize)
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    assert_eq!(
+        resolve_query(env.abs_path("test/epsilon/beta/chi6"), ".."),
+        vec![env.abs_path("test/epsilon/beta")]
+    );
+    assert_eq!(
+        resolve_query(env.abs_path("test/epsilon/beta/chi6"), "..."),
+        vec![env.abs_path("test/epsilon")]
+    );
+    assert_eq!(
+        resolve_query(env.abs_path("test/epsilon/beta/chi6"), ".. delta"),
+        vec![env.abs_path("test/epsilon/beta/del@ta")]
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -285,6 +285,9 @@ fn test_dots() {
     );
     assert_eq!(
         resolve_query(env.abs_path("test/epsilon/beta/chi6"), ".. delta"),
-        vec![env.abs_path("test/epsilon/beta/del@ta").canonicalize().unwrap()]
+        vec![env
+            .abs_path("test/epsilon/beta/del@ta")
+            .canonicalize()
+            .unwrap()]
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -275,14 +275,16 @@ fn test_dots() {
 
     assert_eq!(
         resolve_query(env.abs_path("test/epsilon/beta/chi6"), ".."),
-        vec![env.abs_path("test/epsilon/beta")]
+        // i don't know why but macos is angry without canonicalize
+        // see https://github.com/timothebot/lacy/actions/runs/25148442151/job/74187399440?pr=66
+        vec![env.abs_path("test/epsilon/beta").canonicalize().unwrap()]
     );
     assert_eq!(
         resolve_query(env.abs_path("test/epsilon/beta/chi6"), "..."),
-        vec![env.abs_path("test/epsilon")]
+        vec![env.abs_path("test/epsilon").canonicalize().unwrap()]
     );
     assert_eq!(
         resolve_query(env.abs_path("test/epsilon/beta/chi6"), ".. delta"),
-        vec![env.abs_path("test/epsilon/beta/del@ta")]
+        vec![env.abs_path("test/epsilon/beta/del@ta").canonicalize().unwrap()]
     );
 }


### PR DESCRIPTION
those are literal one-liners, too lazy to split them into PRs

most importantly, fixed nu template (and part of `prompt.rs` not working with symlinks correctly. also removed unnecessary path exists, path type already checks for that and returns null if it does not.

also: 
`Cargo.toml` -> release builds are now stripped, not reason for them to not be, and deps don't pull their unused default features anymore. crates compiling 53 -> 44, total binary size 1264 -> 1048 kb (linux x86_64). also ran `cargo update`.

`Readme.md` and docs -> added info about nushell hack to set --cmd=cd

`commands.rs` -> lacy help init post-help message is now a raw string, no more `\"eval \\\"\\$(lacy init bash)\\\"\"` (actual war crime)

tests -> added `test_dots()` to test `(/home/pheenty/git/lacy) $ y .. other` -> `/home/pheenty/git/other_project`

globally (mostly `prompt.rs` and `query_part.rs`) -> killed a bunch of non-idiomatic (or straight up idiotic) code :face_holding_back_tears:, thanks `cargo clippy -- -W clippy::pedantic`). no architecture changed, just local parts of code, so should be straightforward enough.

all tests pass, clippy is happy, ran cargo fmt, nothing seems to be broken etc etc