### PR TITLE
kill &pathbuf's

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -97,7 +97,7 @@ impl Directory {
         &self.name
     }
 
-    pub fn location(&self) -> &PathBuf {
+    pub fn location(&self) -> &Path {
         &self.location
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -60,7 +60,7 @@ impl Query {
 
         directories
             .iter()
-            .map(|dir| dir.location().clone())
+            .map(|dir| dir.location().to_path_buf())
             .collect()
     }
 
@@ -68,7 +68,7 @@ impl Query {
         if self.query.trim().is_empty() {
             return sub_directories(cwd, 0)
                 .iter()
-                .map(|dir| dir.location().clone())
+                .map(|dir| dir.location().to_path_buf())
                 .collect();
         }
         if self.query.ends_with(' ') {
@@ -76,7 +76,7 @@ impl Query {
                 .results(cwd)
                 .iter()
                 .flat_map(|dir| sub_directories(dir, 0))
-                .map(|dir| dir.location().clone())
+                .map(|dir| dir.location().to_path_buf())
                 .collect();
         }
         if let QueryPart::Text(_) = &self.parts.last().unwrap_or(&QueryPart::Root) {

--- a/src/query_part.rs
+++ b/src/query_part.rs
@@ -56,7 +56,7 @@ impl QueryPart {
             }
             QueryPart::Skip(depth) => dirs
                 .iter()
-                .flat_map(|dir| sub_directories(dir.location().as_path(), *depth))
+                .flat_map(|dir| sub_directories(dir.location(), *depth))
                 .collect(),
             QueryPart::Back(amount) => {
                 let Some(target_dir) = dirs.first() else {
@@ -72,7 +72,7 @@ impl QueryPart {
                 let mut scored_dirs = scored_directories(
                     &dirs
                         .iter()
-                        .flat_map(|dir| sub_directories(dir.location().as_path(), 0))
+                        .flat_map(|dir| sub_directories(dir.location(), 0))
                         .collect::<Vec<_>>(),
                     text.as_str(),
                 );


### PR DESCRIPTION
`pathbuf` is literally a `string`
and you don't use `&string`
you use `&str`
which is `&path`